### PR TITLE
chore: Remove hyperlink from repo

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -2,7 +2,6 @@ repository:
   # See https://developer.github.com/v3/repos/#edit for all available settings.
   name: deepcopy
   description: The deepcopy library.
-  homepage: https://deepcopy.fluidtruck.io
   default_branch: main
 
   has_issues: false


### PR DESCRIPTION
It was set as part of the golang microservice scaffolder, we don't want
it here since this repo is a library.