### PR TITLE
ci: use private gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,23 @@ on:
     branches:
       - main
 
+env:
+  GOLANG_VERSION: '1.19'
+
 jobs:
   setup:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      issues: write
+      pull-requests: write
     outputs:
       comment-id: ${{ steps.setup.outputs.comment-id }}
     steps:
-      - uses: daspn/private-actions-checkout@v2
-        id: actions
-        with:
-          actions_list: '["fluidtruck/github-actions-golang@v1"]'
-          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
-          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
-          return_app_token: true
-
-      - uses: ./.github/actions/github-actions-golang/actions/setup
+      - uses: fluidtruck-platform/github-actions/setup@v2
         id: setup
         with:
-          app-token: ${{ steps.actions.outputs.app-token }}
+          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
 
   lint:
     runs-on: ubuntu-latest
@@ -37,58 +34,47 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: daspn/private-actions-checkout@v2
-        id: actions
-        with:
-          actions_list: '["fluidtruck/github-actions-golang@v1"]'
-          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
-          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
-
-      - uses: ./.github/actions/github-actions-golang/actions/lint
+      - uses: fluidtruck-platform/github-actions/lint@v2
         with:
           github-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          go-version: 1.19
+          golang-version: ${{ env.GOLANG_VERSION }}
 
   test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [lint]
+      issues: write
+      pull-requests: write
+    needs: [setup, lint]
     outputs:
       coverage: ${{ steps.test.outputs.coverage }}
     steps:
       - uses: actions/checkout@v3
 
-      - uses: daspn/private-actions-checkout@v2
-        id: actions
-        with:
-          actions_list: '["fluidtruck/github-actions-golang@v1"]'
-          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
-          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
-
-      - uses: ./.github/actions/github-actions-golang/actions/test
+      - uses: fluidtruck-platform/github-actions/test@v2
         id: test
         with:
           github-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          go-version: 1.19
+          golang-version: ${{ env.GOLANG_VERSION }}
+
+      - uses: fluidtruck-platform/github-actions/preview@v2
+        with:
+          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
+          comment-id: ${{ needs.setup.outputs.comment-id }}
+          coverage: ${{ steps.test.outputs.coverage }}
 
   preview:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     if: ${{ always() }}%
     needs: [setup, test]
     steps:
-      - uses: daspn/private-actions-checkout@v2
-        id: actions
+      - uses: fluidtruck-platform/github-actions/preview@v2
         with:
-          actions_list: '["fluidtruck/github-actions-golang@v1"]'
-          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
-          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
-          return_app_token: true
-
-      - uses: ./.github/actions/github-actions-golang/actions/preview
-        with:
-          app-token: ${{ steps.actions.outputs.app-token }}
+          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
           comment-id: ${{ needs.setup.outputs.comment-id }}
           coverage: ${{ needs.test.outputs.coverage }}
-          status: ${{ needs.deploy.result }}
+          status: ${{ needs.test.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,18 @@ jobs:
     outputs:
       comment-id: ${{ steps.setup.outputs.comment-id }}
     steps:
-      - uses: fluidtruck-platform/github-actions/setup@v2
+      - uses: daspn/private-actions-checkout@v2
+        id: actions
+        with:
+          actions_list: '["fluidtruck-platform/github-actions@v2"]'
+          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
+          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
+          return_app_token: true
+
+      - uses: ./.github/actions/github-actions/setup
         id: setup
         with:
-          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
+          app-token: ${{ steps.actions.outputs.app-token }}
 
   lint:
     runs-on: ubuntu-latest
@@ -34,47 +42,58 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: fluidtruck-platform/github-actions/lint@v2
+      - uses: daspn/private-actions-checkout@v2
+        id: actions
+        with:
+          actions_list: '["fluidtruck/github-actions-golang@v1"]'
+          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
+          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
+
+      - uses: ./.github/actions/github-actions-golang/actions/lint
         with:
           github-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          golang-version: ${{ env.GOLANG_VERSION }}
+          go-version: 1.19
 
   test:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
-    needs: [setup, lint]
+    needs: [lint]
     outputs:
       coverage: ${{ steps.test.outputs.coverage }}
     steps:
       - uses: actions/checkout@v3
 
-      - uses: fluidtruck-platform/github-actions/test@v2
+      - uses: daspn/private-actions-checkout@v2
+        id: actions
+        with:
+          actions_list: '["fluidtruck/github-actions-golang@v1"]'
+          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
+          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
+
+      - uses: ./.github/actions/github-actions-golang/actions/test
         id: test
         with:
           github-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          golang-version: ${{ env.GOLANG_VERSION }}
-
-      - uses: fluidtruck-platform/github-actions/preview@v2
-        with:
-          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          comment-id: ${{ needs.setup.outputs.comment-id }}
-          coverage: ${{ steps.test.outputs.coverage }}
+          go-version: 1.19
 
   preview:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
+    permissions: {}
     if: ${{ always() }}%
     needs: [setup, test]
     steps:
-      - uses: fluidtruck-platform/github-actions/preview@v2
+      - uses: daspn/private-actions-checkout@v2
+        id: actions
         with:
-          app-token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
+          actions_list: '["fluidtruck/github-actions-golang@v1"]'
+          app_id: ${{ secrets.PRIVATE_ACTIONS_APP_ID }}
+          app_private_key: ${{ secrets.PRIVATE_ACTIONS_KEY }}
+          return_app_token: true
+
+      - uses: ./.github/actions/github-actions-golang/actions/preview
+        with:
+          app-token: ${{ steps.actions.outputs.app-token }}
           comment-id: ${{ needs.setup.outputs.comment-id }}
           coverage: ${{ needs.test.outputs.coverage }}
-          status: ${{ needs.test.result }}
+          status: ${{ needs.deploy.result }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,13 +6,14 @@ on:
       - main
 
 jobs:
-  release-please:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3
         with:
           token: ${{ secrets.DEVBOT_GITHUB_TOKEN }}
-          release-type: go
+          release-type: simple
+          bump-minor-pre-major: true
           changelog-types: |-
             [
               {"type":"feat","section":":sparkles: Features","hidden":false},


### PR DESCRIPTION
[PLAT-140](https://fluidtruck.atlassian.net/browse/PLAT-140)

* Deprecate the usage of https://github.com/daspn/private-actions-checkout in favor of calling actions from private GH repositories - https://github.com/fluidtruck-platform/github-actions

[PLAT-44](https://fluidtruck.atlassian.net/browse/PLAT-44)

* Change the action used to create/update comments in PRs - https://github.com/fluidtruck-platform/github-actions/pull/4

[PLAT-46](https://fluidtruck.atlassian.net/browse/PLAT-46)

* Implement NewRelic Change Tracking (Deployment Markers) - https://github.com/fluidtruck-platform/github-actions/commit/07f301262f43a276c8dab56a5c6df2236c6cd0d1
* Stage & Prod deploys only


[PLAT-140]: https://fluidtruck.atlassian.net/browse/PLAT-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-44]: https://fluidtruck.atlassian.net/browse/PLAT-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-46]: https://fluidtruck.atlassian.net/browse/PLAT-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ