### PR TITLE
feat: convert string to []byte

### DIFF
--- a/deepCopy_test.go
+++ b/deepCopy_test.go
@@ -115,6 +115,14 @@ type Thing2 struct {
 	B              uint
 }
 
+type HTTPResponse struct {
+	Body []byte
+}
+
+type HTTPResponse2 struct {
+	Body string
+}
+
 type LocalInspectionType string
 
 const (
@@ -149,6 +157,7 @@ type ClassroomB struct {
 func TestDeepCopy(t *testing.T) {
 	optionalString1 := "pointer string"
 	stringPointer1 := &optionalString1
+	optionalString1Bytes := []byte(optionalString1)
 	num1 := uint64(5)
 	emptyString := ""
 	otherNum1 := uint(5)
@@ -433,6 +442,26 @@ func TestDeepCopy(t *testing.T) {
 			outputPtr: &Thing{},
 			expectedRespPtr: &Thing{
 				B: &num1,
+			},
+		},
+		{
+			name: "string to []byte",
+			input: &HTTPResponse2{
+				Body: optionalString1,
+			},
+			outputPtr: &HTTPResponse{},
+			expectedRespPtr: &HTTPResponse{
+				Body: optionalString1Bytes,
+			},
+		},
+		{
+			name: "[]byte to string",
+			input: &HTTPResponse{
+				Body: optionalString1Bytes,
+			},
+			outputPtr: &HTTPResponse2{},
+			expectedRespPtr: &HTTPResponse2{
+				Body: optionalString1,
 			},
 		},
 		{

--- a/examples_test.go
+++ b/examples_test.go
@@ -122,6 +122,20 @@ var (
 	ex6Float64      = 6.4
 )
 
+// Example 7
+var (
+	ex7String         = "example string"
+	ex7EmptyByteSlice []byte
+	ex7ByteSlice      = []byte("example string")
+)
+
+// Example 8
+var (
+	ex8ByteArray   = []byte("example string")
+	ex8EmptyString string
+	ex8String      = "example string"
+)
+
 func TestDeepCopyExamples(t *testing.T) {
 	testCases := []struct {
 		name              string
@@ -197,10 +211,22 @@ func TestDeepCopyExamples(t *testing.T) {
 			expectedOutputPtr: &ex5Bool,      // true
 		},
 		{
-			name:              "Example 5: type casting, string to float64",
+			name:              "Example 6: type casting, string to float64",
 			input:             ex6String,        // "6.4"
 			outputPtr:         &ex6EmptyFloat64, // empty float64
 			expectedOutputPtr: &ex6Float64,      // 6.4 (float64)
+		},
+		{
+			name:              "Example 7: type casting, string to []byte",
+			input:             ex7String,          // "example string"
+			outputPtr:         &ex7EmptyByteSlice, // empty []byte
+			expectedOutputPtr: &ex7ByteSlice,      // "example string" as a byte array
+		},
+		{
+			name:              "Example 8: type casting, []byte to string",
+			input:             ex8ByteArray,    // []byte("example string")
+			outputPtr:         &ex8EmptyString, // empty string
+			expectedOutputPtr: &ex8String,      // "example string"
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Hey! First of all, thanks for this library. It's a great time saver.

Today I came across a scenario where I hit a limitation in the library. I can convert a `[]byte` into a `string`, however, converting from `string` to `[]byte` was not possible. 